### PR TITLE
fix UWP build error

### DIFF
--- a/src/wavelib.c
+++ b/src/wavelib.c
@@ -3353,7 +3353,7 @@ void setWTConv(wt_object wt, const char *cmethod) {
 }
 
 double* dwt2(wt2_object wt, double *inp) {
-	double *wavecoeff;
+	double *wavecoeff = NULL;
 	int i, J, iter, N, lp, rows_n, cols_n, rows_i, cols_i;
 	int ir, ic, istride,ostride;
 	int aLL, aLH, aHL, aHH, cdim,clen;
@@ -3504,11 +3504,11 @@ void idwt2(wt2_object wt, double *wavecoeff, double *oup) {
 	int istride, ostride, iter, J;
 	int aLL, aLH, aHL, aHH;
 	double *cL, *cH, *X_lp,*orig;
+	double *out = NULL;
 
 	rows = wt->rows;
 	cols = wt->cols;
 	J = wt->J;
-	double *out;
 	
 
 	if (!strcmp(wt->ext, "per")) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,20 +42,6 @@ add_executable(modwt2test modwt2test.c)
 
 target_link_libraries(modwt2test wavelib)
 
-if(UNIX)
-	target_link_libraries(cwttest m)
-	target_link_libraries(dwttest m)
-	target_link_libraries(swttest m)
-	target_link_libraries(modwttest m)
-	target_link_libraries(dwpttest m)
-	target_link_libraries(wtreetest m)
-	target_link_libraries(denoisetest m)
-	target_link_libraries(modwtdenoisetest m)
-	target_link_libraries(dwt2test m)
-	target_link_libraries(swt2test m)
-	target_link_libraries(modwt2test m)
-endif()
-
 set_target_properties(cwttest dwttest swttest modwttest dwpttest wtreetest denoisetest modwtdenoisetest dwt2test swt2test modwt2test
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/test"


### PR DESCRIPTION
Hi! I was trying to add `wavelib` into `vcpkg` recently: https://github.com/microsoft/vcpkg/pull/11611. And the CI system of `vcpkg` reports build failures on `x64-uwp` and `arm-uwp`. The build logs can be downloaded from here: https://dev.azure.com/vcpkg/public/_build/results?buildId=37972&view=artifacts&type=publishedArtifacts

This patch tries to:
- fix the following UWP build errors caught by vcpkg's CI
  src\wavelib.c(3673): error C4703: potentially uninitialized local pointer variable 'out' used
  src\wavelib.c(3499): error C4703: potentially uninitialized local pointer variable 'wavecoeff' used
- move the definition of `out` variable to support old C89 compilers;
  That way, I can use wavelib with VS2010.